### PR TITLE
RELATED: RAIL-3551 add missing style import

### DIFF
--- a/example-insightview/src/index.js
+++ b/example-insightview/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from "react-dom";
 import { BackendProvider, WorkspaceProvider } from "@gooddata/sdk-ui";
 import backend from "./backend";
 
+import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
 import "./styles.css";
 


### PR DESCRIPTION
Since 8.4.0, InsightView needs the styles from sdk-ui-ext imported.